### PR TITLE
テーブルからレコードを全件取得するAPIを実装後、クエリ文字列を指定して検索するAPIも実装

### DIFF
--- a/src/main/java/com/example/nameservice2/Name.java
+++ b/src/main/java/com/example/nameservice2/Name.java
@@ -1,0 +1,19 @@
+package com.example.nameservice2;
+
+public class Name {
+    private int id;
+    private String name;
+
+    public Name(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/example/nameservice2/NameController.java
+++ b/src/main/java/com/example/nameservice2/NameController.java
@@ -1,0 +1,22 @@
+package com.example.nameservice2;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.apache.naming.SelectorContext.prefix;
+
+@RestController
+public class NameController {
+
+    private NameMapper nameMapper;
+    public NameController(NameMapper nameMapper){this.nameMapper =nameMapper;}
+    @GetMapping("/names")
+public List<Name> findByNames(@RequestParam String startsWith){
+
+        return nameMapper.findByNameStartingWith(startsWith);
+    }
+
+}

--- a/src/main/java/com/example/nameservice2/NameController.java
+++ b/src/main/java/com/example/nameservice2/NameController.java
@@ -12,11 +12,14 @@ import static org.apache.naming.SelectorContext.prefix;
 public class NameController {
 
     private NameMapper nameMapper;
-    public NameController(NameMapper nameMapper){this.nameMapper =nameMapper;}
+
+    public NameController(NameMapper nameMapper) {
+        this.nameMapper = nameMapper;
+    }
+
     @GetMapping("/names")
-public List<Name> findByNames(@RequestParam String startsWith){
+    public List<Name> findByNames(@RequestParam String startsWith) {
 
         return nameMapper.findByNameStartingWith(startsWith);
     }
-
 }

--- a/src/main/java/com/example/nameservice2/NameMapper.java
+++ b/src/main/java/com/example/nameservice2/NameMapper.java
@@ -1,0 +1,13 @@
+package com.example.nameservice2;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+@Mapper
+public interface NameMapper {
+
+    @Select("SELECT * FROM names WHERE name NOT LIKE CONCAT(#{prefix}, '%')")
+    List<Name> findByNameStartingWith(String prefix);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=nameservice2
+spring.datasource.url=jdbc:mysql://localhost:3307/name_database
+spring.datasource.username=user
+spring.datasource.password=password


### PR DESCRIPTION
# 概要
掲題の通りです。
名前を２つ追加して、名前が合計4つしました。

### 下記ターミナルで名前を２つ追加した操作内容です。

<img width="1127" alt="スクリーンショット 2024-05-02 21 22 16のコピー" src="https://github.com/koikekatsumi/nameservice2/assets/163390515/fa04c3a6-91ae-45b3-a11d-493c3de0d822">
<img width="818" alt="スクリーンショット 2024-05-20 21 20 19" src="https://github.com/koikekatsumi/nameservice2/assets/163390515/37bd1dda-3138-4196-982e-438370a98ded">

### Name Mapper インターフェースにて、下記のように、NOTを加えました。
```
@Select("SELECT * FROM names WHERE name NOT LIKE CONCAT(#{prefix}, '%')")
```

<img width="844" alt="スクリーンショット 2024-05-19 15 49 05" src="https://github.com/koikekatsumi/nameservice2/assets/163390515/40f1a9d5-1d2f-45a5-8f93-6b7041c1610e">

# 動作確認
Postman を使いました。
下記確認済みです。
※全てのレスポンスのステータスコードが 200 (OK 成功) であること

- レスポンスボディが各々の名前の小文字の頭文字　j、c、l、rで始まる文字以外の名前であること

![スクリーンショット 2024-05-20 21 15 43](https://github.com/koikekatsumi/nameservice2/assets/163390515/780b973d-485a-489b-8c12-29883fa8adfb)

![スクリーンショット 2024-05-20 21 16 02](https://github.com/koikekatsumi/nameservice2/assets/163390515/7757bf0e-110c-4933-8ffb-ecaa954cb8f5)

![スクリーンショット 2024-05-20 21 16 16](https://github.com/koikekatsumi/nameservice2/assets/163390515/c77d3a05-f473-4027-89a0-a50b566edc69)

![スクリーンショット 2024-05-20 21 16 29](https://github.com/koikekatsumi/nameservice2/assets/163390515/c52ca15f-f5f6-45c2-aa7d-1adc47134be7)

- レスポンスボディがデータにない文字で始まる適当なaの文字の時、全ての名前であること

![スクリーンショット 2024-05-21 20 42 26](https://github.com/koikekatsumi/nameservice2/assets/163390515/723d0094-8355-4b0f-b205-bf42515c808d)

-  startsWith= 空白 で検索したときに検索結果が [] すること
![スクリーンショット 2024-05-20 21 41 41](https://github.com/koikekatsumi/nameservice2/assets/163390515/5ef4a36f-0429-4a9b-bb56-93f4d4036f4a)






