### PR TITLE
ワイルドカードインポートは回避とPRの概要の＃の後の半角スペースを設定

### DIFF
--- a/src/main/java/com/example/nameservice2/CoustomeExceptionHandler.java
+++ b/src/main/java/com/example/nameservice2/CoustomeExceptionHandler.java
@@ -4,7 +4,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/com/example/nameservice2/CoustomeExceptionHandler.java
+++ b/src/main/java/com/example/nameservice2/CoustomeExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.example.nameservice2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@RestControllerAdvice
+public class CoustomeExceptionHandler {
+    @ExceptionHandler(NameNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNameNotFoundException(
+            NameNotFoundException e, HttpServletRequest request) {
+        Map body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/nameservice2/NameController.java
+++ b/src/main/java/com/example/nameservice2/NameController.java
@@ -1,13 +1,9 @@
 package com.example.nameservice2;
 
-import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+
 import org.springframework.web.bind.annotation.*;
 
-import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Map;
 
 
 @RestController
@@ -29,6 +25,6 @@ public class NameController {
     public Name getUser(@PathVariable("id") int id) {
         return nameService.findName(id);
     }
-    
+
 }
 

--- a/src/main/java/com/example/nameservice2/NameController.java
+++ b/src/main/java/com/example/nameservice2/NameController.java
@@ -1,25 +1,34 @@
 package com.example.nameservice2;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
-import static org.apache.naming.SelectorContext.prefix;
 
 @RestController
 public class NameController {
 
-    private NameMapper nameMapper;
+    private NameService nameService;
 
-    public NameController(NameMapper nameMapper) {
-        this.nameMapper = nameMapper;
+    public NameController(NameService nameService) {
+        this.nameService = nameService;
     }
 
     @GetMapping("/names")
     public List<Name> findByNames(@RequestParam String startsWith) {
-
-        return nameMapper.findByNameStartingWith(startsWith);
+        List<Name> names = nameService.findNamesStartingWith(startsWith);
+        return names;
     }
+
+    @GetMapping("/names/{id}")
+    public Name getUser(@PathVariable("id") int id) {
+        return nameService.findName(id);
+    }
+    
 }
+

--- a/src/main/java/com/example/nameservice2/NameMapper.java
+++ b/src/main/java/com/example/nameservice2/NameMapper.java
@@ -4,10 +4,18 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface NameMapper {
 
-    @Select("SELECT * FROM names WHERE name NOT LIKE CONCAT(#{prefix}, '%')")
+    @Select("SELECT *FROM names")
+    List<Name> findAll();
+
+    @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%')")
     List<Name> findByNameStartingWith(String prefix);
+
+    @Select("SELECT * FROM names WHERE id =#{id}")
+    Optional<Name> findById(int id);
+
 }

--- a/src/main/java/com/example/nameservice2/NameNotFoundException.java
+++ b/src/main/java/com/example/nameservice2/NameNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.nameservice2;
+
+
+public class NameNotFoundException extends RuntimeException {
+    public NameNotFoundException(String message) {
+        super(message);
+    }
+}
+
+

--- a/src/main/java/com/example/nameservice2/NameService.java
+++ b/src/main/java/com/example/nameservice2/NameService.java
@@ -1,0 +1,33 @@
+package com.example.nameservice2;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class NameService {
+    private NameMapper nameMapper;
+
+    public NameService(NameMapper nameMapper) {
+        this.nameMapper = nameMapper;
+    }
+
+    public List<Name> findNamesStartingWith(String prefix) {
+        return nameMapper.findByNameStartingWith(prefix);
+    }
+
+    public Name findName(int id) {
+        Optional<Name> name = this.nameMapper.findById(id);
+
+        if (name.isPresent()) {
+            return name.get();
+        } else {
+            throw new NameNotFoundException("そのIDは、存在しません。");
+        }
+    }
+}
+
+
+
+

--- a/src/main/java/com/example/nameservice2/NameService.java
+++ b/src/main/java/com/example/nameservice2/NameService.java
@@ -19,11 +19,10 @@ public class NameService {
 
     public Name findName(int id) {
         Optional<Name> name = this.nameMapper.findById(id);
-
         if (name.isPresent()) {
             return name.get();
         } else {
-            throw new NameNotFoundException("そのIDは、存在しません。");
+            throw new NameNotFoundException("そのIDは存在しません。");
         }
     }
 }


### PR DESCRIPTION
# 概要

DBのNameテーブルのレコードに存在しないIDをリクエスト時、例外ハンドリングする処理を実装しました。
その際 @ControllerAdvice を使用して、ハンドリングする専用のCustomeExceptionHandlerクラスを別途作成しました。

# 動作確認
Postmanで存在しないレコードのIDリクエスト（1と2以外を指定）を行い、下記の画像にて意図したレスポンスが返ってきた事を確認済み。

- 404エラーである事

- CustomeExceptionHandlerクラスにて、記載した情報とNameServiceクラス記載のmessageが表示されている事
![341975040-7e0311cd-6ddc-4c38-9ed5-9f0d17a86ba8](https://github.com/koikekatsumi/nameservice2/assets/163390515/81f42432-3bcd-4e7e-b5f3-39b5e316e21c)

- Content-Type が「json」である事
![341975069-124e51ff-b0b2-4383-a0a0-531b882457b3](https://github.com/koikekatsumi/nameservice2/assets/163390515/3f232236-be88-4a5a-9e7e-bfda9b4208f6)

# cURLの結果
<img width="1235" alt="341975515-73084209-27eb-4b51-b984-3b6e8adcefe6" src="https://github.com/koikekatsumi/nameservice2/assets/163390515/f0cd55ef-e961-4f48-8b74-dfa0a7da6dcb">

